### PR TITLE
Add progress bar

### DIFF
--- a/streamjoy/renderers.py
+++ b/streamjoy/renderers.py
@@ -163,6 +163,14 @@ def default_holoviews_renderer(
         kwargs["toolbar"] = None
     elif backend == "matplotlib":
         kwargs["cbar_extend"] = kwargs.get("cbar_extend", "both")
-    hv_obj.opts(**kwargs)
+
+    if isinstance(hv_obj, hv.Overlay):
+        for hv_el in hv_obj:
+            try:
+                hv_el.opts(**kwargs)
+            except Exception:
+                pass
+    else:
+        hv_obj.opts(**kwargs)
 
     return hv_obj

--- a/streamjoy/streams.py
+++ b/streamjoy/streams.py
@@ -1050,6 +1050,24 @@ class AnyStream(MediaStream):
 class HtmlStream(MediaStream):
     _extension = ".html"
 
+    width = param.Integer(default=None, bounds=(1, None), doc="The width of the image.")
+    height = param.Integer(
+        default=None, bounds=(1, None), doc="The height of the image."
+    )
+    sizing_mode = param.Selector(
+        default="scale_width",
+        objects=[
+            "fixed",
+            "stretch_width",
+            "stretch_height",
+            "stretch_both",
+            "scale_width",
+            "scale_height",
+            "scale_both",
+        ],
+        doc="The sizing mode of the image.",
+    )
+
     def __init__(self, **params) -> None:
         import panel as pn
 
@@ -1068,7 +1086,7 @@ class HtmlStream(MediaStream):
             stylesheets=[
                 """
                 .bk-header {
-                    opacity: 0.1; /* Initially hide the element */
+                    opacity: 0.2; /* Initially hide the element */
                     transition: opacity 0.5s ease; /* Smooth transition for the opacity change */
                 }
 
@@ -1078,26 +1096,16 @@ class HtmlStream(MediaStream):
                 """
             ],  # noqa: E501
         )
-        yield tabs
-        image = tabs.objects[0]
-        width = image.width
-        height = image.height
-        tabs.param.update(
-            width=width + 50,
-            height=height,
-        )
         player = pn.widgets.Player(
             name="Time",
             start=0,
-            end=len(tabs) - 1,
             value=0,
             loop_policy="loop",
             interval=int(1000 / self.fps),
-            width=width,
             stylesheets=[
                 """
                 :host(.bk-panel-models-widgets-Player) {
-                    opacity: 0.1;
+                    opacity: 0.2;
                     transition: opacity 0.5s ease;
                 }
 
@@ -1109,10 +1117,48 @@ class HtmlStream(MediaStream):
         )
         player.jslink(tabs, value="active", bidirectional=True)
         self._column.objects = [tabs, player]
-        self._column.param.update(
-            width=width,
-            height=height + 100,
-        )
+        yield tabs
+        image = tabs.objects[0]
+        width = image.object.width
+        height = image.object.height
+        with param.parameterized.batch_call_watchers(self):
+            if self.sizing_mode == "fixed":
+                tabs.param.update(
+                    width=width + 50,
+                    height=height,
+                )
+                player.param.update(
+                    width=width,
+                    end=len(tabs) - 1,
+                )
+                self._column.param.update(
+                    width=width,
+                    height=height + 100,
+                )
+            else:
+                sizing_mode = self.sizing_mode.replace("both", "width")
+                tabs.param.update(
+                    min_height=300,
+                    max_height=int(height * 1.5),
+                    sizing_mode=sizing_mode,
+                )
+                player.param.update(
+                    max_height=150,
+                    max_width=450,
+                    sizing_mode=sizing_mode,
+                    end=len(tabs) - 1,
+                    stylesheets=[
+                        """
+                        :host {
+                            align-self: center;
+                        }
+                        """
+                    ]
+                )
+                self._column.param.update(
+                    min_height=300,
+                    max_height=int(height * 1.5),
+                )
         self._column.save(uri)
 
     def _write_images(self, buf: pn.Tabs, images: list[Future], **write_kwargs) -> None:
@@ -1130,12 +1176,14 @@ class HtmlStream(MediaStream):
                 pause = image.seconds
                 image = image.output
 
+            sizing_mode = self.sizing_mode
             image_tuple = (
                 str(i),
                 pn.pane.Image(
                     image,
-                    width=image.width,
-                    height=image.height,
+                    width=(self.width or image.width) if sizing_mode == "fixed" else None,
+                    height=(self.height or image.height) if sizing_mode == "fixed" else None,
+                    sizing_mode=self.sizing_mode,
                 ),
             )
             buf.append(image_tuple, **write_kwargs)
@@ -1172,9 +1220,9 @@ class HtmlStream(MediaStream):
         Returns:
             The file path or BytesIO object.
         """
+        self._display_in_notebook(self._column, display=self.display)
         uri = self._validate_uri(uri)
         uri = super().write(uri=uri, resources=resources, **kwargs)
-        self._display_in_notebook(self._column, display=self.display)
         return uri if not isinstance(uri, BytesIO) else self._column
 
 

--- a/streamjoy/streams.py
+++ b/streamjoy/streams.py
@@ -16,6 +16,7 @@ import dask.delayed
 import imageio.v3 as iio
 import numpy as np
 import param
+from dask.diagnostics import ProgressBar
 from dask.distributed import Client, Future, fire_and_forget
 from imageio.core.v3_plugin_api import PluginV3
 from PIL import Image, ImageDraw
@@ -168,6 +169,11 @@ class MediaStream(param.Parameterized):
         doc="The number of threads to use per worker.",
     )
 
+    show_progress = param.Boolean(
+        default=True,
+        doc="Whether to show the progress bar when rendering.",
+    )
+
     scratch_dir = param.Path(
         doc="The directory to use for temporary files.", check_exists=False
     )
@@ -201,6 +207,7 @@ class MediaStream(param.Parameterized):
                 params["_tbd_kwargs"][param_key] = params.pop(param_key)
 
         super().__init__(**params)
+        self._progress_bar = ProgressBar(minimum=3 if self.show_progress else np.inf)
 
     @classmethod
     def from_numpy(
@@ -416,7 +423,7 @@ class MediaStream(param.Parameterized):
                 f"got {resources=!r}."
             ) from exc
 
-        if renderer:
+        if renderer and not renderer.__name__.startswith("default"):
             try:
                 iterable_0 = [iterable[0] for iterable in renderer_iterables]
                 renderer(resource_0, *iterable_0, **renderer_kwargs)
@@ -446,7 +453,8 @@ class MediaStream(param.Parameterized):
                 renderer(resource, *iterable, **renderer_kwargs)
                 for resource, *iterable in zip_longest(resources, *renderer_iterables)
             ]
-            resources = dask.compute(jobs, scheduler="threads")[0]
+            with self._progress_bar:
+                resources = dask.compute(jobs, scheduler="threads")[0]
         resource_0 = _utils.get_result(_utils.get_first(resources))
 
         is_like_image = isinstance(resource_0, np.ndarray) and resource_0.ndim == 3
@@ -784,7 +792,7 @@ class Mp4Stream(MediaStream):
             buf.init_video_stream(self.codec, **init_kwargs)
 
         if "crf" in write_kwargs:
-            buf._video_stream.options = {'crf': str(write_kwargs.pop("crf"))}
+            buf._video_stream.options = {"crf": str(write_kwargs.pop("crf"))}
 
         intro_frame = self._create_intro(images)
         self._prepend_intro(buf, intro_frame, **write_kwargs)
@@ -1153,7 +1161,7 @@ class HtmlStream(MediaStream):
                             align-self: center;
                         }
                         """
-                    ]
+                    ],
                 )
                 self._column.param.update(
                     min_height=300,
@@ -1181,8 +1189,12 @@ class HtmlStream(MediaStream):
                 str(i),
                 pn.pane.Image(
                     image,
-                    width=(self.width or image.width) if sizing_mode == "fixed" else None,
-                    height=(self.height or image.height) if sizing_mode == "fixed" else None,
+                    width=(self.width or image.width)
+                    if sizing_mode == "fixed"
+                    else None,
+                    height=(self.height or image.height)
+                    if sizing_mode == "fixed"
+                    else None,
                     sizing_mode=self.sizing_mode,
                 ),
             )


### PR DESCRIPTION
The Dask dashboard isn't very helpful when the scheduler = "threaded" so this shows a progress bar instead.

Also, if it's a default renderer, it skips the check first item.

cc @rsignell