### PR TITLE
Support processes in rendering HoloViews

### DIFF
--- a/streamjoy/_utils.py
+++ b/streamjoy/_utils.py
@@ -186,7 +186,7 @@ def get_first(iterable):
 
 def get_result(future: Future) -> Any:
     if isinstance(future, Future):
-        return future.result()
+        return future.result(timeout=30)
     elif hasattr(future, "compute"):
         return future.compute()
     else:

--- a/streamjoy/serializers.py
+++ b/streamjoy/serializers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from packaging import version
 from inspect import isgenerator
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable
@@ -399,12 +400,14 @@ def serialize_holoviews(
             clims=clims,
         )
 
-    if kwargs.get("processes"):
-        logging.warning(
-            "HoloViews rendering does not support processes; "
-            "setting processes=False."
-        )
-    kwargs["processes"] = False
+    if version.parse(hv.__version__) < version.parse("1.19.0"):
+        if kwargs.get("processes"):
+            logging.warning(
+                "HoloViews<1.19.0 rendering does not support processes; "
+                "setting processes=False; to use processes, upgrade wih "
+                "`pip install 'holoviews>=1.19.0'`"
+            )
+        kwargs["processes"] = False
     return Serialized(resources, renderer, renderer_iterables, renderer_kwargs, kwargs)
 
 

--- a/streamjoy/streams.py
+++ b/streamjoy/streams.py
@@ -1105,7 +1105,7 @@ class HtmlStream(MediaStream):
                 """
             ],  # noqa: E501
         )
-        player = pn.widgets.Player(
+        self._player = pn.widgets.Player(
             name="Time",
             start=0,
             value=0,
@@ -1124,8 +1124,8 @@ class HtmlStream(MediaStream):
                 """
             ],
         )
-        player.jslink(tabs, value="active", bidirectional=True)
-        self._column.objects = [tabs, player]
+        self._player.jslink(tabs, value="active", bidirectional=True)
+        self._column.objects = [tabs, self._player]
         yield tabs
         image = tabs.objects[0]
         width = image.object.width
@@ -1136,7 +1136,7 @@ class HtmlStream(MediaStream):
                     width=width + 50,
                     height=height,
                 )
-                player.param.update(
+                self._player.param.update(
                     width=width,
                     end=len(tabs) - 1,
                 )
@@ -1151,7 +1151,7 @@ class HtmlStream(MediaStream):
                     max_height=int(height * 1.5),
                     sizing_mode=sizing_mode,
                 )
-                player.param.update(
+                self._player.param.update(
                     max_height=150,
                     max_width=450,
                     sizing_mode=sizing_mode,
@@ -1216,6 +1216,7 @@ class HtmlStream(MediaStream):
                     self.fps,
                     **write_kwargs,
                 )
+            self._player.end = len(buf)
             del image
 
     def write(

--- a/streamjoy/wrappers.py
+++ b/streamjoy/wrappers.py
@@ -112,6 +112,7 @@ def wrap_holoviews(
             import holoviews as hv
 
             backend = kwargs.get("backend", hv.Store.current_backend)
+            hv.extension(backend)
             output = renderer(*args, **kwargs)
 
             hv_obj = output


### PR DESCRIPTION
I think `processes=True` (the default) now works @rsignell
```
import xarray as xr
import hvplot.xarray
from streamjoy import stream

ds = xr.tutorial.open_dataset("air_temperature").isel(time=slice(1000))
stream(ds.hvplot.image("lon", "lat"), uri="air.html")
```